### PR TITLE
Relax savon version to 2.8.x

### DIFF
--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Netsuite::VERSION
 
-  gem.add_dependency 'savon', '>= 2.3.0', '< 2.5.0'
+  gem.add_dependency 'savon', '~> 2.8.0'
 
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
Relax savon dependency to prevent UGI.escape warning issue #7


https://github.com/dropstream/active_cart/issues/1588